### PR TITLE
AMP-2 Add docker-compose with MONGO DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# To avoid mac issues
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,7 @@ services:
       - "3000:3000" #specify ports forewarding
     environment:
       - SECRET=Thisismysecret
+  database: # name of the mongo service
+    image: mongo # specify image to build container from
+    ports:
+      - "27017:27017" # specify port forewarding


### PR DESCRIPTION
Add docker-compose as a starting point for docker container services. Init with mongo DB

For test run `docker-compose up` and check with `docker ps` that the mongo container is running